### PR TITLE
Add GitHub action to sync upstream

### DIFF
--- a/.github/workflows/syncUpstream.yml
+++ b/.github/workflows/syncUpstream.yml
@@ -1,0 +1,49 @@
+name: "Upstream Sync"
+
+on:
+  schedule:
+    - cron: "0,30 * * * *"
+    # scheduled at minute 0 and 30
+
+  workflow_dispatch: # click the button on Github repo!
+
+jobs:
+  sync_latest_from_upstream:
+    runs-on: ubuntu-latest
+    name: Sync latest commits from upstream repo
+
+    steps:
+      # REQUIRED step
+      # Step 1: run a standard checkout action, provided by github
+      - name: Checkout target repo
+        uses: actions/checkout@v2
+        with:
+          # optional: set the branch to checkout,
+          # sync action checks out your 'target_sync_branch' anyway
+          ref: main
+          # REQUIRED if your upstream repo is private (see wiki)
+          persist-credentials: false
+
+      # REQUIRED step
+      # Step 2: run the sync action
+      - name: Sync upstream changes
+        id: sync
+        uses: aormsby/Fork-Sync-With-Upstream-action@v3.2
+        with:
+          target_sync_branch: main
+          # REQUIRED 'target_repo_token' exactly like this!
+          target_repo_token: ${{ secrets.GITHUB_TOKEN }}
+          upstream_sync_branch: main
+          upstream_sync_repo: CS3219-AY2223S1/cs3219-project-ay2223s1-g42
+
+      # Step 3: Display a sample message based on the sync output var 'has_new_commits'
+      - name: New commits found
+        if: steps.sync.outputs.has_new_commits == 'true'
+        run: echo "New commits were found to sync."
+
+      - name: No new commits
+        if: steps.sync.outputs.has_new_commits == 'false'
+        run: echo "There were no new commits."
+
+      - name: Show value of 'has_new_commits'
+        run: echo ${{ steps.sync.outputs.has_new_commits }}


### PR DESCRIPTION
reference: https://github.com/aormsby/Fork-Sync-With-Upstream-action#sample-workflow

Used in forks to sync upstream periodically (0th and 30th minute of every hour).

Not tested. Let's push and test.