### PR TITLE
Fix cookie options for local and prod

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,3 +30,5 @@ FRONTEND_URL=http://localhost:3000
 OAUTH_GITHUB_CLIENT_ID=
 # client secret for GitHub OAuth
 OAUTH_GITHUB_CLIENT_SECRET=
+# environment: dev/stage/prod
+NEST_ENV=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -30,5 +30,3 @@ FRONTEND_URL=http://localhost:3000
 OAUTH_GITHUB_CLIENT_ID=
 # client secret for GitHub OAuth
 OAUTH_GITHUB_CLIENT_SECRET=
-# environment: dev/stage/prod
-NEST_ENV=

--- a/backend/src/config/options.ts
+++ b/backend/src/config/options.ts
@@ -1,7 +1,8 @@
 import { CorsOptions } from "@nestjs/common/interfaces/external/cors-options.interface";
 import { CookieOptions } from "express";
 
-const PRODUCTION = process.env.NEST_ENV === "prod";
+const PRODUCTION =
+  process.env.FRONTEND_URL && !process.env.FRONTEND_URL.includes("localhost");
 
 const CSRF_OPTIONS = {
   cookie: true,

--- a/backend/src/config/options.ts
+++ b/backend/src/config/options.ts
@@ -1,17 +1,19 @@
 import { CorsOptions } from "@nestjs/common/interfaces/external/cors-options.interface";
 import { CookieOptions } from "express";
 
+const PRODUCTION = process.env.NEST_ENV === "prod";
+
 const CSRF_OPTIONS = {
   cookie: true,
   httpOnly: true,
-  secure: true,
-  sameSite: "none",
+  secure: PRODUCTION,
+  sameSite: PRODUCTION ? "none" : "lax",
 };
 
 const COOKIE_OPTIONS: CookieOptions = {
   httpOnly: true,
-  secure: true,
-  sameSite: "none",
+  secure: PRODUCTION,
+  sameSite: PRODUCTION ? "none" : "lax",
 };
 
 const CORS_OPTIONS: CorsOptions = {


### PR DESCRIPTION
Now backend prod needs to have a new env variable as follows, `NEST_ENV=prod`, optional for local environment

closes #106.